### PR TITLE
Work with portable installs

### DIFF
--- a/waza_lightfixes.pl
+++ b/waza_lightfixes.pl
@@ -9486,6 +9486,10 @@ if ($os eq "MSWin32") {
 	exit;
 }
 
+if ( ! -e $config_path ) {
+	$config_path = catfile(".", "openmw.cfg");
+}
+
 if ( -e $config_path) {
 	say "found config file '$config_path'";
 	say "making a backup of config...just in case";


### PR DESCRIPTION
the cfg file isn't always in %USERPROFILE%

this lets the app fall back to using a config file found in the same path from where it runs