### PR TITLE
feat: Add openmw_cfg_path and dest_path

### DIFF
--- a/make-windows-exe.ps1
+++ b/make-windows-exe.ps1
@@ -1,0 +1,1 @@
+pp -o waza_lightfixes.exe waza_lightfixes.pl

--- a/waza_lightfixes.cfg
+++ b/waza_lightfixes.cfg
@@ -1,4 +1,6 @@
 [General]
+openmw_cfg_path=
+dest_path=./LightFixes.esp
 disableflickering=1
 hue=0.62
 saturation=0.8

--- a/waza_lightfixes.pl
+++ b/waza_lightfixes.pl
@@ -9434,6 +9434,10 @@ sub tes3cmd_main {
 
 ### BEGIN CONFIG 
 
+# Loading OpenMW from standard or portable location.
+my $openmw_cfg_path = "";
+my $dest_path = "";
+
 my $DISABLE_FLICKERING => 1; 
 
 ## HSV and light radius multipliers 
@@ -9468,6 +9472,8 @@ if (-e $ini_path) {
 	$VAL = $cfg->val("General", "value", $VAL);
 	$RAD = $cfg->val("General", "radius", $RAD);
 	$DISABLE_FLICKERING = $cfg->val("General", "disableflickering", $DISABLE_FLICKERING);
+	$openmw_cfg_path = $cfg->val("General", "openmw_cfg_path", "");
+	$dest_path = $cfg->val("General", "dest_path", "LightFixes.esp");
 }
 
 if ($DISABLE_FLICKERING) { say "Disable Flickering \t= True"; }
@@ -9475,23 +9481,27 @@ if ($DISABLE_FLICKERING) { say "Disable Flickering \t= True"; }
 my $config_path = "";
 my $os = $Config{osname};
 
-if ($os eq "MSWin32") {
-	$config_path = catfile(File::HomeDir->my_documents, "My Games", "OpenMW", "openmw.cfg");
-} elsif ($os eq "linux") {
-	$config_path = catfile(File::HomeDir->my_home, ".config", "openmw", "openmw.cfg"); 
-} elsif ($os eq "darwin") {
-	$config_path = catfile(File::HomeDir->my_home, "Library", "Preferences", "openmw", "openmw.cfg");
+if ($openmw_cfg_path eq "") {
+	if ($os eq "MSWin32") {
+		$config_path = catfile(File::HomeDir->my_documents, "My Games", "OpenMW", "openmw.cfg");
+	} elsif ($os eq "linux") {
+		$config_path = catfile(File::HomeDir->my_home, ".config", "openmw", "openmw.cfg"); 
+	} elsif ($os eq "darwin") {
+		$config_path = catfile(File::HomeDir->my_home, "Library", "Preferences", "openmw", "openmw.cfg");
+	} else {
+		say "ERROR: could not detect correct operating system, aborting :(";
+		exit;
+	}
 } else {
-	say "ERROR: could not detect correct operating system, aborting :(";
-	exit;
+	$config_path = $openmw_cfg_path;
 }
 
 if ( -e $config_path) {
 	say "found config file '$config_path'";
 	say "making a backup of config...just in case";
 	copy($config_path, "openmw.cfg.bck") or say "failed creating backup :(";
-	} else {
-	say "no config file found, aborting!";
+} else {
+	say "no config file found ($config_path), aborting!";
 	exit;
 }
 
@@ -9536,7 +9546,7 @@ foreach my $plugin (@plugin_paths) {
 	}
 }
 
-my $output = open_for_output("LightFixes.esp");
+my $output = open_for_output($dest_path);
 print $output make_header({
 	author => "...",
 	description => "...",


### PR DESCRIPTION
* Add `openmw_cfg_path` to config file.
  * If field is empty, defaults to the standard OpenMW config location.
  * If field is non-empty, attempts to load the config file from the location.
* Add `dest_path` to config file.
  * Defines the location and filename of the final esp file.
* Add simple script to build windows `exe` from script.

Addresses #8.